### PR TITLE
fix: experience layout overflow and data-driven collapse

### DIFF
--- a/src/lib/components/Experience.svelte
+++ b/src/lib/components/Experience.svelte
@@ -8,8 +8,6 @@
 
   let { experience }: Props = $props();
 
-  const isIntern = (job: Experience) => job.position.toLowerCase().includes('intern');
-
   let expanded = $state<boolean[]>([]);
   $effect(() => {
     if (expanded.length === 0) expanded = experience.map(() => false);
@@ -31,7 +29,7 @@
               <h3 class="position">{job.position}</h3>
               <span class="company">@ {job.company}</span>
             </div>
-            {#if !isIntern(job) || expanded[i]}
+            {#if !job.collapse || expanded[i]}
               <ul class="summary">
                 {#each job.summary as point}
                   <li>{point}</li>
@@ -43,7 +41,7 @@
                 {/each}
               </div>
             {/if}
-            {#if isIntern(job)}
+            {#if job.collapse}
               <button class="toggle-btn" onclick={() => (expanded[i] = !expanded[i])}>
                 {expanded[i] ? '▾ less' : '▸ details'}
               </button>
@@ -64,8 +62,8 @@
 
   .entry {
     display: grid;
-    grid-template-columns: 180px 1fr;
-    gap: 24px;
+    grid-template-columns: 220px 1fr;
+    gap: 32px;
   }
 
   .entry-meta {

--- a/src/lib/data/data.json
+++ b/src/lib/data/data.json
@@ -226,6 +226,7 @@
       "location": "Toronto, Ontario",
       "skills": ["Java", "React", "PostgreSQL", "Selenium"],
       "environment": "MacOS",
+      "collapse": true,
       "summary": [
         "Developed 50+ Selenium QA modules in Java for automated UI testing, improving coverage from 10% to over 85%.",
         "Optimized SQL queries by up to 80%, satisfying strict performance thresholds.",
@@ -242,6 +243,7 @@
       "location": "Ottawa, Ontario",
       "skills": ["JavaScript", "jQuery", "CSS", "PHP"],
       "environment": "Linux",
+      "collapse": true,
       "summary": [
         "Refactored 10000+ lines of JavaScript in dozens of modules to improve platform scalability and readability.",
         "Developed reusable web modules and built new application pages based on client specifications.",
@@ -257,6 +259,7 @@
       "location": "Ottawa, Ontario",
       "skills": ["JavaScript", "Excel"],
       "environment": "MacOS",
+      "collapse": true,
       "summary": [
         "Designed QA coverage workflows using Excel.",
         "Implemented language localization for a web application using JavaScript.",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,7 @@ export interface Experience {
   skills: string[];
   environment: string;
   summary: string[];
+  collapse?: boolean;
 }
 
 export interface Education {


### PR DESCRIPTION
## Summary

- Widens the experience metadata column (`180px` → `220px`, gap `24px` → `32px`) so long dates like "September 2018 — September 2022" no longer overflow into the job title
- Replaces the `isIntern()` position-name heuristic with a data-driven `collapse?: boolean` field on the `Experience` type
- Marks three older entries as `collapse: true` in `data.json`: Rubikloud intern, DLS Front-End Developer Intern, and DLS Technical Support Coordinator (previously missed by the heuristic)

## Test plan

- [ ] `npm run lint && npm run format:check && npm run check && npm test` — all pass (62 tests)
- [ ] `npm run dev` — confirm dates no longer visually collide with job titles
- [ ] Confirm "Technical Support Coordinator" now collapses/expands correctly
- [ ] Confirm non-collapse entries (Infrastructure Engineer, Software Engineer) still show full details

🤖 Generated with [Claude Code](https://claude.com/claude-code)