### PR TITLE
test: expand coverage for collapse logic, data shape, and optional minor

### DIFF
--- a/src/lib/components/Education.test.ts
+++ b/src/lib/components/Education.test.ts
@@ -52,4 +52,17 @@ describe('Education component', () => {
     const { container } = render(Education, { props: { education: twoEntries } });
     expect(container.querySelectorAll('.entry')).toHaveLength(2);
   });
+
+  it('does not render minor element when minor is absent', () => {
+    const noMinor: EducationType[] = [
+      {
+        school: 'MIT',
+        program: 'Computer Science',
+        startDate: 'September 2020',
+        endDate: 'May 2024',
+      },
+    ];
+    const { container } = render(Education, { props: { education: noMinor } });
+    expect(container.querySelector('.minor')).toBeNull();
+  });
 });

--- a/src/lib/components/Experience.test.ts
+++ b/src/lib/components/Experience.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import Experience from './Experience.svelte';
 import data from '$lib/data/data.json';
 import type { Experience as ExperienceType } from '$lib/types';
@@ -58,5 +58,48 @@ describe('Experience component', () => {
     const firstEntry = container.querySelectorAll('.entry')[0];
     const bullets = firstEntry.querySelectorAll('.summary li');
     expect(bullets.length).toBeGreaterThan(0);
+  });
+
+  it('collapse entries start with summary and chips hidden', () => {
+    const { container } = render(Experience, { props: { experience } });
+    // entries 2, 3, 4 are collapse: true (Rubikloud intern, DLS intern, DLS coordinator)
+    for (const i of [2, 3, 4]) {
+      const entry = container.querySelectorAll('.entry')[i];
+      expect(entry.querySelector('.summary')).toBeNull();
+      expect(entry.querySelector('.skill-chips')).toBeNull();
+    }
+  });
+
+  it('collapse entries render a toggle button', () => {
+    const { container } = render(Experience, { props: { experience } });
+    for (const i of [2, 3, 4]) {
+      const entry = container.querySelectorAll('.entry')[i];
+      expect(entry.querySelector('.toggle-btn')).not.toBeNull();
+    }
+  });
+
+  it('non-collapse entries do not render a toggle button', () => {
+    const { container } = render(Experience, { props: { experience } });
+    // entries 0 and 1 are the two Xero roles (no collapse flag)
+    for (const i of [0, 1]) {
+      const entry = container.querySelectorAll('.entry')[i];
+      expect(entry.querySelector('.toggle-btn')).toBeNull();
+    }
+  });
+
+  it('clicking toggle reveals summary and chips', async () => {
+    const { container } = render(Experience, { props: { experience } });
+    const entry = container.querySelectorAll('.entry')[2]; // Rubikloud intern
+    const btn = entry.querySelector('.toggle-btn') as HTMLElement;
+    await fireEvent.click(btn);
+    expect(entry.querySelector('.summary')).not.toBeNull();
+    expect(entry.querySelector('.skill-chips')).not.toBeNull();
+  });
+
+  it('Technical Support Coordinator is collapsed by default', () => {
+    const { container } = render(Experience, { props: { experience } });
+    const entry = container.querySelectorAll('.entry')[4];
+    expect(entry.querySelector('.summary')).toBeNull();
+    expect(entry.querySelector('.toggle-btn')).not.toBeNull();
   });
 });

--- a/src/lib/data/data.test.ts
+++ b/src/lib/data/data.test.ts
@@ -21,6 +21,37 @@ describe('data.json shape', () => {
         expect(Array.isArray(entry.summary)).toBe(true);
       }
     });
+
+    it('collapse field, when present, is a boolean', () => {
+      for (const entry of data.experience) {
+        if ('collapse' in entry) {
+          expect(typeof (entry as { collapse: unknown }).collapse).toBe('boolean');
+        }
+      }
+    });
+
+    it('the three older entries are marked collapse: true', () => {
+      const find = (company: string, position: string) =>
+        data.experience.find((e) => e.company === company && e.position === position) as
+          | { collapse?: boolean }
+          | undefined;
+
+      expect(find('Rubikloud', 'Software Developer Intern')?.collapse).toBe(true);
+      expect(find('DLS Technology Corporation', 'Front-End Developer Intern')?.collapse).toBe(true);
+      expect(find('DLS Technology Corporation', 'Technical Support Coordinator')?.collapse).toBe(
+        true
+      );
+    });
+
+    it('main roles do not have collapse set', () => {
+      const find = (company: string, position: string) =>
+        data.experience.find((e) => e.company === company && e.position === position) as
+          | { collapse?: boolean }
+          | undefined;
+
+      expect(find('Xero', 'Infrastructure Engineer')?.collapse).toBeUndefined();
+      expect(find('Xero (Hubdoc)', 'Software Engineer')?.collapse).toBeUndefined();
+    });
   });
 
   describe('project entries', () => {


### PR DESCRIPTION
## Summary

Adds 9 tests across three files to cover behaviour introduced in #35:

- **Experience** — collapse entries hidden by default, toggle button presence, clicking toggle reveals content, `Technical Support Coordinator` specifically tested, non-collapse entries have no toggle button
- **data.json** — `collapse` field type validation, correct entries marked `true`, main Xero roles confirmed unmarked
- **Education** — optional `minor` field absent renders no `.minor` element (tests the `{#if edu.minor}` branch)

## Test plan

- [ ] `npm test` — 71 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)