### PR TITLE
chore: add wrangler.toml for Cloudflare Pages preview deployments

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+name = "laurenceli-portfolio"
+pages_build_output_dir = "build"
+
+[env.preview]


### PR DESCRIPTION
Pins the Cloudflare Pages build config (project name, output dir) to the repo so it is reviewable and portable. Production branch is set to cf-never-deploy in the Cloudflare dashboard to keep GitHub Pages as the sole production endpoint; this file only enables per-PR preview URLs.