### PR TITLE
test: verify Cloudflare Pages preview deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,4 @@ name = "laurenceli-portfolio"
 pages_build_output_dir = "build"
 
 [env.preview]
+# test comment — verifying Cloudflare Pages preview deployments


### PR DESCRIPTION
## Summary
- Adds a comment to `wrangler.toml` to trigger a Cloudflare Pages preview build
- Verifies that per-PR preview URLs are generated and posted as PR comments

## What to check
- [ ] Cloudflare build appears in the PR's Checks section
- [ ] A PR comment is posted with the preview URL (`https://feature-test-cf-preview.laurenceli-portfolio.pages.dev` or similar)
- [ ] Visiting the preview URL loads the site correctly

> This PR can be closed without merging once the preview URL is confirmed working.