### PR TITLE
test: swap accent colour for CF Pages preview check

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,8 +33,8 @@
     --bg: #0d0d0d;
     --surface: #161616;
     --surface-2: #1e1e1e;
-    --accent: #48e59f;
-    --accent-dim: rgba(72, 229, 159, 0.12);
+    --accent: #3dd6f5;
+    --accent-dim: rgba(61, 214, 245, 0.12);
     --text-primary: #f0f0f0;
     --text-secondary: #888888;
     --text-muted: #555555;


### PR DESCRIPTION
## Summary
- Changes `--accent` from green (`#48e59f`) to blue (`#3dd6f5`) so the visual difference is immediately obvious in the preview URL
- Confirms Cloudflare Pages preview deployment is working end-to-end

## What to check
- [ ] Cloudflare Pages build appears in Checks (should say "Cloudflare Pages" not "Workers Builds")
- [ ] PR comment posted with preview URL
- [ ] Preview URL loads the site with a **blue** accent colour
- [ ] Production at `laurenceli.github.io` still shows the original **green** accent

> Close without merging once confirmed.